### PR TITLE
feature: add libjpeg-turbo and enable JPEG codec in libtiff/GDAL

### DIFF
--- a/cppjs-packages/cppjs-package-gdal/cppjs-package-gdal-wasm/cppjs.build.js
+++ b/cppjs-packages/cppjs-package-gdal/cppjs-package-gdal-wasm/cppjs.build.js
@@ -51,6 +51,7 @@ export default {
         `-DSQLite3_INCLUDE_DIR=${depPaths.sqlite3.header}`, `-DSQLite3_LIBRARY=${depPaths.sqlite3.lib}`,
         `-DPROJ_INCLUDE_DIR=${depPaths.proj.header}`, `-DPROJ_LIBRARY_RELEASE=${depPaths.proj.lib}`,
         `-DTIFF_INCLUDE_DIR=${depPaths.tiff.header}`, `-DTIFF_LIBRARY_RELEASE=${depPaths.tiff.lib}`,
+        '-DGDAL_USE_JPEG=ON', `-DJPEG_INCLUDE_DIR=${depPaths.jpeg.header}`, `-DJPEG_LIBRARY_RELEASE=${depPaths.jpeg.lib}`,
         `-DGEOTIFF_INCLUDE_DIR=${depPaths.geotiff.header}`, `-DGEOTIFF_LIBRARY_RELEASE=${depPaths.geotiff.lib}`,
         `-DZLIB_INCLUDE_DIR=${depPaths.z.header}`, `-DZLIB_LIBRARY_RELEASE=${depPaths.z.lib}`,
         `-DSPATIALITE_INCLUDE_DIR=${depPaths.spatialite.header}`, `-DSPATIALITE_LIBRARY=${depPaths.spatialite.lib}`,

--- a/cppjs-packages/cppjs-package-gdal/cppjs-package-gdal-wasm/cppjs.config.js
+++ b/cppjs-packages/cppjs-package-gdal/cppjs-package-gdal-wasm/cppjs.config.js
@@ -2,6 +2,7 @@ import expatWasm from '@cpp.js/package-expat-wasm/cppjs.config.js';
 import geosWasm from '@cpp.js/package-geos-wasm/cppjs.config.js';
 import geotiffWasm from '@cpp.js/package-geotiff-wasm/cppjs.config.js';
 import iconvWasm from '@cpp.js/package-iconv-wasm/cppjs.config.js';
+import jpegturboWasm from '@cpp.js/package-jpegturbo-wasm/cppjs.config.js';
 import projWasm from '@cpp.js/package-proj-wasm/cppjs.config.js';
 import spatialiteWasm from '@cpp.js/package-spatialite-wasm/cppjs.config.js';
 import sqlite3Wasm from '@cpp.js/package-sqlite3-wasm/cppjs.config.js';
@@ -15,6 +16,7 @@ export default {
     geosWasm,
     geotiffWasm,
     iconvWasm,
+    jpegturboWasm,
     projWasm,
     spatialiteWasm,
     sqlite3Wasm,

--- a/cppjs-packages/cppjs-package-gdal/cppjs-package-gdal-wasm/package.json
+++ b/cppjs-packages/cppjs-package-gdal/cppjs-package-gdal-wasm/package.json
@@ -24,6 +24,7 @@
         "@cpp.js/package-geos-wasm": "workspace:^",
         "@cpp.js/package-geotiff-wasm": "workspace:^",
         "@cpp.js/package-iconv-wasm": "workspace:^",
+        "@cpp.js/package-jpegturbo-wasm": "workspace:^",
         "@cpp.js/package-proj-wasm": "workspace:^",
         "@cpp.js/package-spatialite-wasm": "workspace:^",
         "@cpp.js/package-sqlite3-wasm": "workspace:^",

--- a/cppjs-packages/cppjs-package-geotiff/cppjs-package-geotiff-wasm/cppjs.build.js
+++ b/cppjs-packages/cppjs-package-geotiff/cppjs-package-geotiff-wasm/cppjs.build.js
@@ -3,7 +3,7 @@ const platformBuild = {
 };
 
 const platformExtraLibs = {
-    'wasm': ['-lsqlite3'],
+    'wasm': ['-lsqlite3', '-ljpeg'],
 };
 
 export default {

--- a/cppjs-packages/cppjs-package-geotiff/cppjs-package-geotiff-wasm/cppjs.config.js
+++ b/cppjs-packages/cppjs-package-geotiff/cppjs-package-geotiff-wasm/cppjs.config.js
@@ -1,12 +1,14 @@
 import projWasm from '@cpp.js/package-proj-wasm/cppjs.config.js';
 import tiffWasm from '@cpp.js/package-tiff-wasm/cppjs.config.js';
 import zlibWasm from '@cpp.js/package-zlib-wasm/cppjs.config.js';
+import jpegturboWasm from '@cpp.js/package-jpegturbo-wasm/cppjs.config.js';
 
 export default {
   dependencies: [
     projWasm,
     tiffWasm,
     zlibWasm,
+    jpegturboWasm,
   ],
   general: {
     name: 'geotiff'

--- a/cppjs-packages/cppjs-package-geotiff/cppjs-package-geotiff-wasm/package.json
+++ b/cppjs-packages/cppjs-package-geotiff/cppjs-package-geotiff-wasm/package.json
@@ -22,7 +22,8 @@
     "dependencies": {
         "@cpp.js/package-proj-wasm": "workspace:^",
         "@cpp.js/package-tiff-wasm": "workspace:^",
-        "@cpp.js/package-zlib-wasm": "workspace:^"
+        "@cpp.js/package-zlib-wasm": "workspace:^",
+        "@cpp.js/package-jpegturbo-wasm": "workspace:^"
     },
     "devDependencies": {
         "cpp.js": "workspace:^"

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm/cppjs.build.js
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm/cppjs.build.js
@@ -1,0 +1,9 @@
+export default {
+    getURL: (version) => `https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/${version}/libjpeg-turbo-${version}.tar.gz`,
+    buildType: 'cmake',
+    getBuildParams: () => [
+        '-DENABLE_SHARED=OFF',
+        '-DENABLE_STATIC=ON',
+        '-DWITH_TURBOJPEG=OFF', // GDAL uses standard libjpeg API only; skip libturbojpeg.a (unused) to save build output.
+    ],
+};

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm/cppjs.config.js
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm/cppjs.config.js
@@ -1,0 +1,18 @@
+export default {
+    dependencies:[
+    ],
+    general: {
+        name: 'jpeg',
+    },
+    export: {
+        type: 'cmake',
+        libName: [
+            'jpeg'
+        ],
+    },
+    paths: {
+        config: import.meta.url,
+        base: '../..',
+        output: 'dist'
+    }
+};

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm/package.json
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "@cpp.js/package-jpegturbo-wasm",
+    "version": "2.0.0-beta.12",
+    "nativeVersion": "3.1.4.1",
+    "description": "This package provides a libjpegturbo library compiled with Cpp.js, enabling seamless usage of JPEG functionalities in JavaScript, WebAssembly and React Native projects.",
+    "homepage": "https://github.com/bugra9/cpp.js/tree/main/cppjs-packages/cppjs-package-jpegturbo#readme",
+    "repository": "https://github.com/bugra9/cpp.js.git",
+    "type": "module",
+    "license": "(IJG AND BSD-3-Clause AND Zlib)",
+    "keywords": [
+        "jpegturbo",
+        "libjpeg-turbo",
+        "cpp.js-package",
+        "webassembly",
+        "react-native"
+    ],
+    "private": true,
+
+    "scripts": {
+        "build": "cppjs build -p wasm",
+        "clear": "rm -rf .cppjs dist",
+        "prepublishOnly": "cppjs build -p wasm"
+    },
+    "dependencies": {
+    },
+    "devDependencies": {
+        "cpp.js": "workspace:^"
+    }
+}

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/.npmignore
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/.npmignore
@@ -1,0 +1,6 @@
+*.tgz
+.cppjs
+*.dylib
+dist/prebuilt/Android-arm64-v8a/lib/*.a
+dist/prebuilt/Android-x86_64/lib/*.a
+dist/prebuilt/**/bin

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/CHANGELOG.md
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @cpp.js/package-jpegturbo
+
+## 1.0.0
+
+- 🚀 first release

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/LICENSE
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/LICENSE
@@ -1,0 +1,147 @@
+libjpeg-turbo Licenses
+======================
+
+libjpeg-turbo is covered by two compatible BSD-style open source licenses:
+
+- The IJG (Independent JPEG Group) License, which is listed in
+  [README.ijg](README.ijg)
+
+  This license applies to the libjpeg API library and associated programs,
+  including any code inherited from libjpeg and any modifications to that
+  code.
+
+- The Modified (3-clause) BSD License, which is listed below
+
+  This license applies to the TurboJPEG API library and associated programs,
+  [libspng](https://libspng.org) (which is used by cjpeg and djpeg), and the
+  build/test system.
+
+  * The TurboJPEG API library wraps the libjpeg API library, so in the context
+    of the overall TurboJPEG API library, both the terms of the IJG License and
+    the terms of the Modified (3-clause) BSD License apply.
+  * cjpeg and djpeg use libspng, so in the context of those programs, both the
+    terms of the IJG License and the terms of the Modified (3-clause) BSD
+    License apply.
+
+
+Component Licenses
+==================
+
+Some of libjpeg-turbo's modules and internal dependencies are covered by less
+restrictive licenses, but in the context of libjpeg-turbo as a whole, the terms
+of the less restrictive licenses are subsumed by either the IJG License or the
+Modified BSD License.  (In other words, the terms of the less restrictive
+licenses are satisfied if the terms of the IJG and Modified BSD Licenses are
+satisfied.)
+
+- The libjpeg-turbo SIMD source code and zlib are covered by the
+  [zlib License](https://spdx.org/licenses/Zlib.html), which is subsumed by the
+  IJG License in the context of the cjpeg and djpeg programs and the libjpeg
+  API library.
+
+- Some of the libspng source code is covered by the
+  [PNG Reference Library License v2](https://spdx.org/licenses/libpng-2.0.html),
+  which is subsumed by the IJG License in the context of the cjpeg and djpeg
+  programs and the TurboJPEG API library.
+
+- Most of the libspng source code is covered by the
+  [Simplified (2-clause) BSD License](https://spdx.org/licenses/BSD-2-Clause.html),
+  which is subsumed by the Modified BSD License in the context of the cjpeg and
+  djpeg programs and the TurboJPEG API library.
+
+
+Complying with the libjpeg-turbo Licenses
+=========================================
+
+This section provides a roll-up of the libjpeg-turbo licensing terms, to the
+best of our understanding.  This is not a license in and of itself.  It is
+intended solely for clarification.
+
+1.  If you are distributing a modified version of the libjpeg-turbo source,
+    then:
+
+    1.  You cannot alter or remove any existing copyright or license notices
+        from the source.
+
+        **Origin**
+        - Clause 1 of the IJG License
+        - Clause 1 of the Modified BSD License
+
+    2.  You must add your own copyright notice to the header of each source
+        file you modified, so others can tell that you modified that file.  (If
+        there is not an existing copyright header in that file, then you can
+        simply add a notice stating that you modified the file.)
+
+        **Origin**
+        - Clause 1 of the IJG License
+
+    3.  You must include the IJG README file, and you must not alter any of the
+        copyright or license text in that file.
+
+        **Origin**
+        - Clause 1 of the IJG License
+
+2.  If you are distributing only libjpeg-turbo binaries without the source, or
+    if you are distributing an application that statically links with
+    libjpeg-turbo, then:
+
+    1.  Your product documentation must include a message stating:
+
+        This software is based in part on the work of the Independent JPEG
+        Group.
+
+        **Origin**
+        - Clause 2 of the IJG license
+
+    2.  If your binary distribution includes or uses the TurboJPEG API or
+        associated programs, cjpeg, or djpeg, then your product documentation
+        must include the text of the Modified BSD License (see below.)
+
+        **Origin**
+        - Clause 2 of the Modified BSD License
+
+3.  You cannot use the name of the IJG or The libjpeg-turbo Project or the
+    contributors thereof in advertising, publicity, etc.
+
+    **Origin**
+    - IJG License
+    - Clause 3 of the Modified BSD License
+
+4.  The authors and distributors do not warrant libjpeg-turbo to be free of
+    defects, nor do we accept any liability for undesirable consequences
+    resulting from your use of the software.
+
+    **Origin**
+    - IJG License
+    - Modified BSD License
+
+
+The Modified (3-clause) BSD License
+===================================
+
+Copyright (C) 2009-2026 D. R. Commander<br>
+Copyright (C) 2018-2023 Randy <randy408@protonmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name of the libjpeg-turbo Project nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS",
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/README.md
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/README.md
@@ -1,0 +1,8 @@
+# @cpp.js/package-jpegturbo
+**Precompiled jpegturbo library built with cpp.js for seamless integration in JavaScript, WebAssembly and React Native projects.**  
+
+## License
+This project includes the precompiled libjpeg-turbo library, which is distributed under the 
+[libjpeg-turbo Licenses](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/LICENSE.md).
+
+jpeg-turbo Homepage: [https://libjpeg-turbo.org](https://libjpeg-turbo.org)

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/cppjs.config.js
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/cppjs.config.js
@@ -1,0 +1,10 @@
+import jpegturboWasm from '@cpp.js/package-jpegturbo-wasm/cppjs.config.js';
+
+export default {
+  dependencies: [
+      jpegturboWasm
+  ],
+  paths: {
+    config: import.meta.url
+  }
+};

--- a/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/package.json
+++ b/cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@cpp.js/package-jpegturbo",
+    "version": "2.0.0-beta.12",
+    "nativeVersion": "3.1.4.1",
+    "description": "This package provides a libjpegturbo library compiled with Cpp.js, enabling seamless usage of JPEG functionalities in JavaScript, WebAssembly and React Native projects.",
+    "homepage": "https://github.com/bugra9/cpp.js/tree/main/cppjs-packages/cppjs-package-jpegturbo#readme",
+    "repository": "https://github.com/bugra9/cpp.js.git",
+    "type": "module",
+    "license": "(IJG AND BSD-3-Clause AND Zlib)",
+    "keywords": [
+        "jpegturbo",
+        "libjpeg-turbo",
+        "cpp.js-package",
+        "webassembly",
+        "react-native"
+    ],
+    "private": true,
+    "dependencies": {
+        "@cpp.js/package-jpegturbo-wasm": "workspace:^"
+    },
+    "devDependencies": {
+        "cpp.js": "workspace:^"
+    }
+}

--- a/cppjs-packages/cppjs-package-tiff/cppjs-package-tiff-wasm/cppjs.build.js
+++ b/cppjs-packages/cppjs-package-tiff/cppjs-package-tiff-wasm/cppjs.build.js
@@ -1,8 +1,11 @@
 export default {
     getURL: (version) => `https://download.osgeo.org/libtiff/tiff-${version}.tar.gz`,
     buildType: 'cmake',
-    getBuildParams: () => [
+    getBuildParams: (platform, depPaths) => [
         '-Dtiff-tools=OFF', '-Dtiff-tests=OFF', '-Dtiff-contrib=OFF',
         '-Dtiff-docs=OFF', '-Dld-version-script=OFF',
+        '-Djpeg=ON',
+        `-DJPEG_INCLUDE_DIR=${depPaths.jpeg.header}`,
+        `-DJPEG_LIBRARY=${depPaths.jpeg.lib}`,
     ],
 };

--- a/cppjs-packages/cppjs-package-tiff/cppjs-package-tiff-wasm/cppjs.config.js
+++ b/cppjs-packages/cppjs-package-tiff/cppjs-package-tiff-wasm/cppjs.config.js
@@ -1,8 +1,10 @@
 import zlibWasm from '@cpp.js/package-zlib-wasm/cppjs.config.js';
+import jpegturboWasm from '@cpp.js/package-jpegturbo-wasm/cppjs.config.js';
 
 export default {
   dependencies: [
     zlibWasm,
+    jpegturboWasm,
   ],
   general: {
     name: 'tiff'

--- a/cppjs-packages/cppjs-package-tiff/cppjs-package-tiff-wasm/package.json
+++ b/cppjs-packages/cppjs-package-tiff/cppjs-package-tiff-wasm/package.json
@@ -20,7 +20,8 @@
         "prepublishOnly": "cppjs build -p wasm"
     },
     "dependencies": {
-        "@cpp.js/package-zlib-wasm": "workspace:^"
+        "@cpp.js/package-zlib-wasm": "workspace:^",
+        "@cpp.js/package-jpegturbo-wasm": "workspace:^"
     },
     "devDependencies": {
         "cpp.js": "workspace:^"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "scripts": {
-        "build:packages": "pnpm --filter=@cpp.js/package-iconv* run build && pnpm --filter=@cpp.js/package-zlib* run build && pnpm --filter=@cpp.js/package-expat* run build && pnpm --filter=@cpp.js/package-webp* run build && pnpm --filter=@cpp.js/package-tiff* run build && pnpm --filter=@cpp.js/package-sqlite3* run build && pnpm --filter=@cpp.js/package-proj* run build && pnpm --filter=@cpp.js/package-geotiff* run build && pnpm --filter=@cpp.js/package-geos* run build && pnpm --filter=@cpp.js/package-spatialite* run build && pnpm --filter=@cpp.js/package-openssl* run build && pnpm --filter=@cpp.js/package-curl* run build && pnpm --filter=@cpp.js/package-gdal* run build",
+        "build:packages": "pnpm --filter=@cpp.js/package-iconv* run build && pnpm --filter=@cpp.js/package-zlib* run build && pnpm --filter=@cpp.js/package-expat* run build && pnpm --filter=@cpp.js/package-webp* run build && pnpm --filter=@cpp.js/package-jpegturbo* run build && pnpm --filter=@cpp.js/package-tiff* run build && pnpm --filter=@cpp.js/package-sqlite3* run build && pnpm --filter=@cpp.js/package-proj* run build && pnpm --filter=@cpp.js/package-geotiff* run build && pnpm --filter=@cpp.js/package-geos* run build && pnpm --filter=@cpp.js/package-spatialite* run build && pnpm --filter=@cpp.js/package-openssl* run build && pnpm --filter=@cpp.js/package-curl* run build && pnpm --filter=@cpp.js/package-gdal* run build",
         "build:samples": "pnpm --filter=@cpp.js/sample-* run build",
         "build:samples:lib": "pnpm --filter=@cpp.js/sample-lib-* run build",
         "build:samples:lib:wasm": "pnpm --filter=@cpp.js/sample-lib-* run build:wasm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@cpp.js/package-iconv-wasm':
         specifier: workspace:^
         version: link:../../cppjs-package-iconv/cppjs-package-iconv-wasm
+      '@cpp.js/package-jpegturbo-wasm':
+        specifier: workspace:^
+        version: link:../../cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm
       '@cpp.js/package-proj-wasm':
         specifier: workspace:^
         version: link:../../cppjs-package-proj/cppjs-package-proj-wasm
@@ -425,6 +428,9 @@ importers:
 
   cppjs-packages/cppjs-package-geotiff/cppjs-package-geotiff-wasm:
     dependencies:
+      '@cpp.js/package-jpegturbo-wasm':
+        specifier: workspace:^
+        version: link:../../cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm
       '@cpp.js/package-proj-wasm':
         specifier: workspace:^
         version: link:../../cppjs-package-proj/cppjs-package-proj-wasm
@@ -468,6 +474,22 @@ importers:
         version: link:../../../cppjs-core/cpp.js
 
   cppjs-packages/cppjs-package-iconv/cppjs-package-iconv-wasm:
+    devDependencies:
+      cpp.js:
+        specifier: workspace:^
+        version: link:../../../cppjs-core/cpp.js
+
+  cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo:
+    dependencies:
+      '@cpp.js/package-jpegturbo-wasm':
+        specifier: workspace:^
+        version: link:../cppjs-package-jpegturbo-wasm
+    devDependencies:
+      cpp.js:
+        specifier: workspace:^
+        version: link:../../../cppjs-core/cpp.js
+
+  cppjs-packages/cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm:
     devDependencies:
       cpp.js:
         specifier: workspace:^
@@ -728,6 +750,9 @@ importers:
 
   cppjs-packages/cppjs-package-tiff/cppjs-package-tiff-wasm:
     dependencies:
+      '@cpp.js/package-jpegturbo-wasm':
+        specifier: workspace:^
+        version: link:../../cppjs-package-jpegturbo/cppjs-package-jpegturbo-wasm
       '@cpp.js/package-zlib-wasm':
         specifier: workspace:^
         version: link:../../cppjs-package-zlib/cppjs-package-zlib-wasm


### PR DESCRIPTION
Build libjpeg-turbo 3.1.4.1 statically with emscripten as the @cpp.js/package-jpegturbo (and -wasm) workspace package, then wire it into libtiff via -Djpeg=ON + JPEG_INCLUDE_DIR / JPEG_LIBRARY, and into GDAL via -DGDAL_USE_JPEG=ON + JPEG_INCLUDE_DIR / JPEG_LIBRARY_RELEASE.

This lets libtiff's JPEG codec resolve at runtime, so GeoTIFFs with Compression=JPEG decode correctly instead of failing with "Cannot open TIFF file due to missing codec JPEG".

## Notes:
- The newly added packages (cppjs-package-jpegturbo and
  cppjs-package-jpegturbo-wasm) are defined with `private: true`
  for now. Please flip them to publishable when ready.
- iOS and Android sub-packages are not included at this time,
  as I don't have a test environment for those platforms.